### PR TITLE
Fix crash on jailed devices

### DIFF
--- a/SponsorBlockRequest.m
+++ b/SponsorBlockRequest.m
@@ -5,10 +5,10 @@
 + (void)getSponsorTimes:(NSString *)videoID completionTarget:(id)target completionSelector:(SEL)sel apiInstance:(NSString *)apiInstance {
     __block NSMutableArray *skipSegments = [NSMutableArray array];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-    NSString *categories = @"[%22sponsor%22,%20%22intro%22,%20%22outro%22,%20%22interaction%22,%20%22selfpromo%22,%20%22music_offtopic%22]";
+    NSArray *categoriesArray = @[@"\"sponsor\"", @"\"intro\"", @"\"outro\"", @"\"interaction\"", @"\"selfpromo\"", @"\"music_offtopic\""];
     //NSString *categories = @"[%22sponsor%22,%20%22intro%22,%20%22outro%22,%20%22interaction%22,%20%22selfpromo%22,%20%22music_offtopic%22,%20%22preview%22,%20%22filler%22]";
 
-    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/skipSegments?videoID=%@&categories=%@", apiInstance, videoID, categories]]];
+    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/skipSegments?videoID=%@&categories=[%@]", apiInstance, videoID, [categoriesArray componentsJoinedByString:@","]]]];
     request.HTTPMethod = @"GET";
     NSURLSessionDataTask *dataTask = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (data != nil && error == nil) {

--- a/SponsorBlockRequest.m
+++ b/SponsorBlockRequest.m
@@ -5,10 +5,12 @@
 + (void)getSponsorTimes:(NSString *)videoID completionTarget:(id)target completionSelector:(SEL)sel apiInstance:(NSString *)apiInstance {
     __block NSMutableArray *skipSegments = [NSMutableArray array];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-    NSArray *categoriesArray = @[@"\"sponsor\"", @"\"intro\"", @"\"outro\"", @"\"interaction\"", @"\"selfpromo\"", @"\"music_offtopic\""];
+    NSString *categories = @"[\"sponsor\",\"intro\",\"outro\",\"interaction\",\"selfpromo\",\"music_offtopic\",\"preview\",\"poi_highlight\",\"filler\"]";
+    NSString *encCategories = [categories stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+
     //NSString *categories = @"[%22sponsor%22,%20%22intro%22,%20%22outro%22,%20%22interaction%22,%20%22selfpromo%22,%20%22music_offtopic%22,%20%22preview%22,%20%22filler%22]";
 
-    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/skipSegments?videoID=%@&categories=[%@]", apiInstance, videoID, [categoriesArray componentsJoinedByString:@","]]]];
+    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/skipSegments?videoID=%@&categories=%@", apiInstance, videoID, encCategories]]];
     request.HTTPMethod = @"GET";
     NSURLSessionDataTask *dataTask = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (data != nil && error == nil) {


### PR DESCRIPTION
The previous formatting resulted in the string '['categories parameter does not match format requirements.']' on jailed devices, which caused the app to crash when trying to process a string as a dictionary